### PR TITLE
static code scanner fixes and  minor improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,7 @@ go 1.14
 
 require (
 	github.com/sirupsen/logrus v1.4.2
+	k8s.io/api v0.17.0
+	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
 )

--- a/keysync/server.go
+++ b/keysync/server.go
@@ -1,7 +1,7 @@
 package keysync
 
 import (
-	"crypto/md5"
+	"crypto/md5" // #nosec G501
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	KeyTypeFieldSelector = "type=key"
+	keyTypeFieldSelector = "type=key"
 )
 
 // KeySyncServer contains the parameters required for operation of the
@@ -42,20 +42,18 @@ func (ks *KeySyncServer) Start() error {
 
 	// Create channel for immediate call for the first time
 	for {
-		select {
-		case <-time.After(ks.Interval):
-			secList, err := secClient.List(metav1.ListOptions{
-				FieldSelector: "type=key",
-			})
-			if err != nil {
-				logrus.Errorf("Error listing secrets: %v", err)
-				continue
-			}
+		<-time.After(ks.Interval)
 
-			ks.syncSecretsToLocalKeys(secList)
+		secList, err := secClient.List(metav1.ListOptions{
+			FieldSelector: keyTypeFieldSelector,
+		})
+		if err != nil {
+			logrus.Errorf("Error listing secrets: %v", err)
+			continue
 		}
+
+		ks.syncSecretsToLocalKeys(secList)
 	}
-	return nil
 }
 
 // syncSecretsToLocalKeys syncs the secrets to the local keys, errors are logged
@@ -76,7 +74,7 @@ func (ks *KeySyncServer) syncSecretsToLocalKeys(secList *corev1.SecretList) {
 
 		// For each file in the secret
 		for filename, data := range s.Data {
-			hashString := fmt.Sprintf("%x", md5.Sum(data))
+			hashString := fmt.Sprintf("%x", md5.Sum(data)) // #nosec G401
 
 			// Hash contents of each file, and check if they exists
 			// already before writing

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -65,6 +65,7 @@ gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.4
 gopkg.in/yaml.v2
 # k8s.io/api v0.17.0
+## explicit
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/apps/v1
@@ -106,6 +107,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apimachinery v0.17.0
+## explicit
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/api/resource


### PR DESCRIPTION
I'm working on integrating the synchronizer application with our IKS offerings. As part of the internal CICD pipeline we are using gosec and golangci-lint, that have some complaints (mainly false alarms). These complaints are workarounded in this PR, and I added some really minor improvements.

---

# gosec complains

```
[/home/travis/gopath/src/github.ibm.com/alchemy-containers/addon-image-key-synchronizer/k8s-enc-image-operator/keysync/server.go:79] - G401 (CWE-326): Use of weak cryptographic primitive (Confidence: HIGH, Severity: MEDIUM)
    78: 		for filename, data := range s.Data {
  > 79: 			hashString := fmt.Sprintf("%x", md5.Sum(data))
    80: 
[/home/travis/gopath/src/github.ibm.com/alchemy-containers/addon-image-key-synchronizer/k8s-enc-image-operator/keysync/server.go:4] - G501 (CWE-327): Blocklisted import crypto/md5: weak cryptographic primitive (Confidence: HIGH, Severity: MEDIUM)
    3: import (
  > 4: 	"crypto/md5"
    5: 	"fmt"
Summary:
   Files: 2
   Lines: 199
   Nosec: 0
  Issues: 2
```

false alarm, marked them to be ignored by gosec

# golangci-lint complains

```
keysync/server.go:45:3: S1037: should use time.Sleep instead of elaborate way of sleeping (gosimple)
		select {
		^
keysync/server.go:44:2: S1000: should use for range instead of for { select {} } (gosimple)
	for {
	^
keysync/server.go:58:2: unreachable: unreachable code (govet)
	return nil
	^
```

falsy alarm on `for {} + select {}`, workarounded

# minor improvements

- using the predefined type selector constant
- updated go.mod to contain all the used dependencies