### PR TITLE
configurable permissions and ownership

### DIFF
--- a/keysync/server_test.go
+++ b/keysync/server_test.go
@@ -47,10 +47,13 @@ func TestKeySync(t *testing.T) {
 	)
 
 	ksc := KeySyncServerConfig{
-		K8sClient:  fakeClient,
-		Interval:   interval,
-		KeySyncDir: tmpDir,
-		Namespace:  namespace,
+		K8sClient:          fakeClient,
+		Interval:           interval,
+		KeySyncDir:         tmpDir,
+		Namespace:          namespace,
+		KeyFilePermissions: os.FileMode(0600),
+		KeyFileOwnerUID:    -1,
+		KeyFileOwnerGID:    -1,
 	}
 	kss := NewKeySyncServer(ksc)
 
@@ -177,10 +180,13 @@ func TestKeySyncAddHandlersBeforeStart(t *testing.T) {
 	}
 
 	ksc := KeySyncServerConfig{
-		K8sClient:  fakeClient,
-		Interval:   interval,
-		KeySyncDir: tmpDir,
-		Namespace:  namespace,
+		K8sClient:          fakeClient,
+		Interval:           interval,
+		KeySyncDir:         tmpDir,
+		Namespace:          namespace,
+		KeyFilePermissions: os.FileMode(0600),
+		KeyFileOwnerUID:    -1,
+		KeyFileOwnerGID:    -1,
 	}
 
 	kss := NewKeySyncServer(ksc)
@@ -311,10 +317,13 @@ func TestKeySyncAddHandlersAfterStart(t *testing.T) {
 	}
 
 	ksc := KeySyncServerConfig{
-		K8sClient:  fakeClient,
-		Interval:   interval,
-		KeySyncDir: tmpDir,
-		Namespace:  namespace,
+		K8sClient:          fakeClient,
+		Interval:           interval,
+		KeySyncDir:         tmpDir,
+		Namespace:          namespace,
+		KeyFilePermissions: os.FileMode(0600),
+		KeyFileOwnerUID:    -1,
+		KeyFileOwnerGID:    -1,
 	}
 
 	kss := NewKeySyncServer(ksc)


### PR DESCRIPTION
We need a way to control the permissions and the ownership on the created files.

(This (combined with `CAP_CHOWN` capability) makes it possible to run the sychronizer as a non-root user, but set the ownership on the key files to root.)

---

❗  This PR is based on https://github.com/IBM/k8s-enc-image-operator/pull/18, should be merged after that. ❗ 